### PR TITLE
Fix not being able to cancel /upload conversation

### DIFF
--- a/myinstantsbot.py
+++ b/myinstantsbot.py
@@ -296,10 +296,18 @@ def main():
                 MessageHandler(Filters.voice, get_voice, run_async=True),
                 MessageHandler(Filters.audio, get_audio, run_async=True),
             ],
-            NAME: [MessageHandler(Filters.text & (~ Filters.text(["/cancel"])), get_name, run_async=True)],
+            NAME: [
+                MessageHandler(
+                    Filters.text & (~Filters.command(["/cancel"])),
+                    get_name,
+                    run_async=True,
+                )
+            ],
             CONFIRMATION: [
                 MessageHandler(
-                    Filters.text & (~ Filters.text(["/cancel"])), name_confirmation_and_upload, run_async=True
+                    Filters.text & (~Filters.command(["/cancel"])),
+                    name_confirmation_and_upload,
+                    run_async=True,
                 )
             ],
         },


### PR DESCRIPTION
Currently, a user cannot exit the /upload conversation properly. This PR fixes it by not catching '/cancel' during the conversation (by also using `~ Filters.text(["/cancel"])` instead of only the catch-all filter `Filters.text`)
By the way, I'll look into using `inline_keyboard` for this conversation...